### PR TITLE
feat: inputs for sonarqube

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 <p align="center">
-  <a href="https://github.com/wealthsimple/toolbox-script/actions"><img alt="toolbox-script status" src="https://github.com/wealthsimple/toolbox-script/workflows/pipeline/badge.svg"></a>
+  <a href="https://github.com/wealthsimple/toolbox-script/actions">
+    <img alt="toolbox-script status" src="https://github.com/wealthsimple/toolbox-script/workflows/pipeline/badge.svg">
+  </a>
 </p>
 
 # Wealthsimple Toolbox Script
 
-*Not meant for public use*. This Action is based on a private package,
+_Not meant for public use_. This Action is based on a private package,
 unavailable to the public. Only useful for private Wealthsimple projects.
+
+## Code analysis with SonarQube
+
+```yaml
+- name: Run SonarQube analysis
+  uses: wealthsimple/toolbox-script@v1
+  with:
+    script: toolbox.sonarqube.run()
+    sonarqube_host: ${{ secrets.SONARQUBE_HOST }}
+    sonarqube_token: ${{ secrets.SONARQUBE_TOKEN }}
+```

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,12 @@ inputs:
   script:
     required: true
     description: The script to run
+  sonarqube_host:
+    required: false
+    description: The SonarQube hostname
+  sonarqube_token:
+    required: false
+    description: The SonarQube token
 outputs:
   result:
     description: The return value of the script, stringified with `JSON.stringify`


### PR DESCRIPTION
Now that we can run the SonarQube scanner using actions-toolbox, expose the needed inputs.