### PR TITLE
Add lint_yaml input option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,9 @@ name: Wealthsimple Toolbox Script
 description: Run scripts using Wealthsimple's Actions Toolbox (internal only)
 author: Wealthsimple
 inputs:
+  lint_yaml:
+    required: false
+    description: Opts in to run yamllint
   script:
     required: true
     description: The script to run


### PR DESCRIPTION
# Why?

Enables support to run `yamllint` as per: https://github.com/wealthsimple/actions-toolbox/blob/main/src/ruby/lint.ts#L8