### PR TITLE
feat: a tag to point workflows to

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,16 +1,28 @@
+---
 name: Pipeline
 on:
-  pull_request:
-  push:
-    branches:
-      - main
-
+  - push
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: ./
+      - uses: actions/setup-node@v2
         with:
-          script: |
-            toolbox.run();
+          node-version: '12'
+          always-auth: true
+          registry-url: ${{ secrets.ACTIONS_NEXUS_NPM_ENDPOINT }}
+      - name: Install dependencies
+        run: |
+          npm config set _auth "${{ secrets.ACTIONS_NEXUS_NPM_READ_TOKEN }}"
+          yarn install
+      - name: Release
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          git config --global user.email "${{ secrets.ACTIONS_GITHUB_EMAIL }}"
+          git config --global user.name "${{ secrets.ACTIONS_GITHUB_USERNAME }}"
+
+          yarn run semantic-release --branches main
+
+          git tag --force --annotate v1 --message "The latest v1 release [skip ci]"
+          git push origin v1

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -22,15 +22,18 @@ jobs:
         run: yarn install
       - name: Commit latest actions-toolbox
         run: |
-          yarn add @wealthsimple/actions-toolbox@${{ github.event.inputs.version }}
-          yarn build
-
           git config --global user.email "${{ secrets.ACTIONS_GITHUB_EMAIL }}"
           git config --global user.name "${{ secrets.ACTIONS_GITHUB_USERNAME }}"
 
-          git commit -am "feat: update actions-toolbox to ${{ github.event.inputs.version }}"
+          yarn add @wealthsimple/actions-toolbox@${{ github.event.inputs.version }}
+          yarn build
+
+          git commit --all --message "feat: update actions-toolbox to ${{ github.event.inputs.version }}"
           git push origin main
 
           yarn run semantic-release --branches main
+
+          git tag --force --annotate v1 --message "The latest v1 release [skip ci]"
+          git push origin v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Have CI maintain a `v1` tag that can be referenced by our projects'
workflows (i.e. `uses: wealthsimple/toolbox-script@v1`). While we're at
it, make it so that changes to the repository get automatically
released, just as dependency bumps currently do.