### PR TITLE
print toolbox-script version

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,13 @@ import * as core from '@actions/core';
 import * as io from '@actions/io';
 import * as toolbox from '@wealthsimple/actions-toolbox';
 import { callAsyncFunction } from './async-function';
+import { version as toolboxScriptVersion } from '../package.json';
 
 process.on('unhandledRejection', handleError);
 main().catch(handleError);
 
 async function main(): Promise<void> {
+  core.info(`toolbox-script v${toolboxScriptVersion}`);
   toolbox.version();
 
   const script = core.getInput('script', { required: true });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "strict": true,
     "target": "es2019"
   },


### PR DESCRIPTION
#### Why
So we can easily tell from gh actions what version is being run, just like with `actions-toolbox`

#### What Changed
Print the `toolbox-script` version on startup