### PR TITLE
chore: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+#### Why
+
+#### What Changed
+
+#### Pre-merge
+
+- [ ] My PR title follows the conventions of
+      [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format)


### PR DESCRIPTION
#### Why
I just merged something that didn't have the right PR title

#### What Changed
Add a PR template so it's harder to forget to do this

#### Pre-merge

- [X] My PR title follows the conventions of
      [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format)

~marking as `feat` to trigger a release for the [last thing](https://github.com/wealthsimple/toolbox-script/pull/33) I just merged~ a new release was cut before merging
