### PR TITLE
Branch publishing

### DIFF
--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Set npm auth
         run: npm config set _auth "${{ secrets.ACTIONS_NEXUS_NPM_READ_TOKEN }}"
       - name: yarn install
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=name;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: branch
         run: yarn install
       - name: Commit latest actions-toolbox
         run: |
@@ -29,11 +33,14 @@ jobs:
           yarn build
 
           git commit --all --message "feat: update actions-toolbox to ${{ github.event.inputs.version }}"
-          git push origin main
+          git push origin ${{ steps.branch.outputs.name }}
 
-          yarn run semantic-release --branches main
-
-          git tag --force --annotate v1 --message "The latest v1 release [skip ci]"
-          git push --force origin v1
+          if [ "${{ steps.branch.outputs.name }}" = 'main' ]; then
+            yarn run semantic-release --extends ./release/main
+            git tag --force --annotate v1 --message "The latest v1 release [skip ci]"
+            git push --force origin v1
+          else
+            yarn run semantic-release --extends ./release/branches
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-<p align="center">
-  <a href="https://github.com/wealthsimple/toolbox-script/actions">
-    <img alt="toolbox-script status" src="https://github.com/wealthsimple/toolbox-script/workflows/pipeline/badge.svg">
-  </a>
-</p>
-
 # Wealthsimple Toolbox Script
+
+[![Github Actions Badge](https://github.com/wealthsimple/toolbox-script/actions/workflows/pipeline.yml/badge.svg)](https://github.com/wealthsimple/toolbox-script/actions)
+
+[![Github Actions Badge](https://github.com/wealthsimple/toolbox-script/actions/workflows/update-main.yml/badge.svg)](https://github.com/wealthsimple/toolbox-script/actions)
 
 _Not meant for public use_. This Action is based on a private package,
 unavailable to the public. Only useful for private Wealthsimple projects.

--- a/package.json
+++ b/package.json
@@ -45,15 +45,6 @@
     "ts-jest": "^26.5.6",
     "typescript": "^4.2.4"
   },
-  "release": {
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      "@semantic-release/npm",
-      "@semantic-release/git",
-      "@semantic-release/github"
-    ]
-  },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node"

--- a/release/branches.js
+++ b/release/branches.js
@@ -1,0 +1,17 @@
+// eslint-disable-next-line
+module.exports = {
+  branches: [
+    {
+      name: 'main',
+    },
+    {
+      name: '!(main|depfu*)',
+      prerelease: true,
+    },
+  ],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/npm',
+  ],
+};

--- a/release/main.js
+++ b/release/main.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const branches_config = require('./branches');
+
+const modified_config = Object.assign({}, branches_config);
+modified_config.plugins.push(
+  '@semantic-release/github',
+  '@semantic-release/git',
+);
+
+module.exports = modified_config;


### PR DESCRIPTION
#### Why
So we can test changes to this action without comitting to `main` first

#### What Changed
support using `update-actions` workflow in other branches

Also see the WIP: https://github.com/wealthsimple/actions-toolbox/compare/branch-publishing
(this is a pre-requisite for `actions-toolbox` to work)

#### Pre-merge

- [X] My PR title follows the conventions of
      [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format)
