### PR TITLE
ci: use actions/cache

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,7 +12,18 @@ jobs:
           node-version: '12'
           always-auth: true
           registry-url: ${{ secrets.ACTIONS_NEXUS_NPM_ENDPOINT }}
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
+        if: steps.yarn.cache.outputs.cache-hit != 'true'
         run: |
           npm config set _auth "${{ secrets.ACTIONS_NEXUS_NPM_READ_TOKEN }}"
           yarn install

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -16,14 +16,26 @@ jobs:
           node-version: '12'
           always-auth: true
           registry-url: ${{ secrets.ACTIONS_NEXUS_NPM_ENDPOINT }}
-      - name: Set npm auth
-        run: npm config set _auth "${{ secrets.ACTIONS_NEXUS_NPM_READ_TOKEN }}"
-      - name: yarn install
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        if: steps.yarn.cache.outputs.cache-hit != 'true'
+        run: |
+          npm config set _auth "${{ secrets.ACTIONS_NEXUS_NPM_READ_TOKEN }}"
+          yarn install
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=name;]$(echo ${GITHUB_REF#refs/heads/})"
         id: branch
-        run: yarn install
+      - run: yarn install
       - name: Commit latest actions-toolbox
         run: |
           git config --global user.email "${{ secrets.ACTIONS_GITHUB_EMAIL }}"


### PR DESCRIPTION
#### Why
Because nothing in life is free, including github actions build time

#### What Changed
Cache dependencies

#### Pre-merge

- [x] My PR title follows the conventions of
      [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format)
