### PR TITLE
ci: use semantic-release/git for branches releasese

### DIFF
--- a/release/branches.js
+++ b/release/branches.js
@@ -13,5 +13,6 @@ module.exports = {
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     '@semantic-release/npm',
+    '@semantic-release/git',
   ],
 };

--- a/release/main.js
+++ b/release/main.js
@@ -4,7 +4,6 @@ const branches_config = require('./branches');
 const modified_config = Object.assign({}, branches_config);
 modified_config.plugins.push(
   '@semantic-release/github',
-  '@semantic-release/git',
 );
 
 module.exports = modified_config;


### PR DESCRIPTION
#### Why
GitHub actions points to repos, if we want to point to branches, the branches need to have compiled toolbox just like `main` does.  the `@semantic-release/git` will commit the changes to the branch automatically

#### What Changed
use `@semantic-release/git` in non-main workflows

#### Pre-merge

- [x] My PR title follows the conventions of
      [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format)
