### PR TITLE
feat: post script [do not merge]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,10 +60,10 @@ inputs:
   transifex_token:
     required: false
     description: Token for Transifex API
-
 outputs:
   result:
     description: The return value of the script, stringified with `JSON.stringify`
 runs:
   using: 'node12'
-  main: 'dist/index.js'
+  main: 'dist/main.js'
+  post: 'dist/post.js'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "lib/main.js",
   "scripts": {
     "all": "yarn run build && yarn run format && yarn run lint && yarn test",
-    "build": "ncc build src/main.ts",
+    "build": "yarn build:main && yarn build:post",
+    "build:main": "ncc build src/main.ts && mv dist/index.js dist/main.js",
+    "build:post": "ncc build src/post.ts && mv dist/index.js dist/post.js",
     "format": "prettier --write **/*.ts",
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,15 +2,9 @@ import * as core from '@actions/core';
 import * as io from '@actions/io';
 import * as toolbox from '@wealthsimple/actions-toolbox';
 import { callAsyncFunction } from './async-function';
-import { version as toolboxScriptVersion } from '../package.json';
-
-process.on('unhandledRejection', handleError);
-main().catch(handleError);
+import { run } from './run';
 
 async function main(): Promise<void> {
-  core.info(`toolbox-script v${toolboxScriptVersion}`);
-  toolbox.version();
-
   const script = core.getInput('script', { required: true });
   const result = await callAsyncFunction(
     { require: require, core, io, toolbox },
@@ -21,8 +15,4 @@ async function main(): Promise<void> {
   core.setOutput('result', output);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function handleError(err: any): void {
-  console.error(err);
-  core.setFailed(`Unhandled error: ${err}`);
-}
+run(main);

--- a/src/post.ts
+++ b/src/post.ts
@@ -1,0 +1,4 @@
+import * as toolbox from '@wealthsimple/actions-toolbox';
+import { run } from './run';
+
+run(toolbox.post.run);

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,0 +1,16 @@
+import * as core from '@actions/core';
+import * as toolbox from '@wealthsimple/actions-toolbox';
+import { version as toolboxScriptVersion } from '../package.json';
+
+export async function run<T>(f: () => Promise<T>): Promise<T | void> {
+  core.info(`toolbox-script v${toolboxScriptVersion}`);
+  toolbox.version();
+  process.on('unhandledRejection', handleError);
+  return f().catch(handleError);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function handleError(err: any): void {
+  console.error(err);
+  core.setFailed(`Unhandled error: ${err}`);
+}


### PR DESCRIPTION
**Do Not Merge**
Requires an update to `actions-toolbox` before the `toolbox.post` module is available.  I have tested locally with actions-toolbox `v1.23.0-cache-sonar.1` and `yarn build` works as expected.

#### Why
So we have a generic `post` entrypoint for `toolbox-script` to automatically run things (as needed) after a job's completion.

docs:
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions

#### What Changed
Add a `post` script to our action

#### Pre-merge

- [X] My PR title follows the conventions of
      [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format)
