### PR TITLE
fix: set default github_api_token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,7 @@ inputs:
   github_api_token:
     required: false
     description: Github API token for accessing Wealthsimple private repos
+    default: ${{ github.token }}
   github_username:
     required: false
     description: Github username for creating tags / comments


### PR DESCRIPTION
#### Why
Many steps require a github token, but only need to default one. This sets the default for github_api_token to the default read only token.

#### What Changed
Pass default github.token to github_api_token so that it is available in all actions that use this script.

#### Pre-merge

- [x] My PR title follows the conventions of
      [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format)
