### PR TITLE
feat: add input to enable strict docs build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
   dockerfile_path:
     required: false
     description: Path to the Dockerfile to build
+  docs_strict:
+    required: false
+    description: Enable strict checking when building docs site
+    default: false
   enable_datadog:
     required: false
     description: Enable Datadog tracing for tests


### PR DESCRIPTION
#### Why
Need to add an option to allow for adding strict option to docs build process. Related PR: https://github.com/wealthsimple/actions-toolbox/pull/181

#### What Changed
- Added docs_strict input, default to false 

#### Pre-merge

- [x] My PR title follows the conventions of
      [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format)
