### PR TITLE
feat: add force_deploy parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   enable_knapsack:
     required: false
     description: Enable Knapsack for RSpec tests
+  force_deploy:
+    required: false
+    description: Force deploy on a non-main branch
   image_name:
     required: false
     description: Name of the Docker image to build

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,7 @@ inputs:
   force_deploy:
     required: false
     description: Force deploy on a non-main branch
+    default: false
   image_name:
     required: false
     description: Name of the Docker image to build


### PR DESCRIPTION
#### Why
The chat-service repo deploys from both master and preprod branches. This PR adds an parameter to allow deploys from a non-main branch. Normally actions-toolbox will only publish from main branches, which is a valuable check to have, so this will allow us to skip the check in the exceptional cases.

#### What Changed
- Added force_deploy parameter

#### Pre-merge

- [x] My PR title follows the conventions of
      [semantic-release](https://github.com/semantic-release/semantic-release#commit-message-format)
